### PR TITLE
Improve typescript support

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -2,10 +2,10 @@
 all: dist dist.browser
 
 dist: src/index.ts
-	@tsc -p tsconfig.json
+	@tsc --declaration -p tsconfig.json
 
 dist.browser: src/index.ts
-	@tsc -p tsconfig.browser.json
+	@tsc --declaration -p tsconfig.browser.json
 
 src/index.ts: $(SCHEMA)
 	@echo "==> create $@"


### PR DESCRIPTION
Without including the type declaration file in `dist/`, I'm not able to read any type info when importing apex-logs into a typescript codebase.

This PR includes a change to the Makefile that I think will address that issue, but there may be additional steps needed for complete out-of-the-box typescript support .